### PR TITLE
.h5 file support fixes

### DIFF
--- a/fast_dp/fast_dp.py
+++ b/fast_dp/fast_dp.py
@@ -20,9 +20,8 @@ import fast_dp
 from fast_dp.run_job import get_number_cpus
 from fast_dp.cell_spacegroup import check_spacegroup_name, check_split_cell, \
      generate_primitive_cell
+import fast_dp.image_readers
 import fast_dp.output
-
-from fast_dp.image_readers import read_image_metadata, check_file_readable
 
 from fast_dp.autoindex import autoindex
 from fast_dp.integrate import integrate
@@ -135,10 +134,10 @@ class FastDP:
         if not os.path.isfile(start_image):
             raise RuntimeError('no image provided: data collection cancelled?')
 
-        check_file_readable(start_image)
+        fast_dp.image_readers.check_file_readable(start_image)
 
         self._start_image = start_image
-        self._metadata = read_image_metadata(self._start_image)
+        self._metadata = fast_dp.image_readers.read_image_metadata(self._start_image)
 
         # check that all of the images are present
 
@@ -417,8 +416,7 @@ def main():
         options.last_image = xia2_format.group(3)
 
     if options.lib_name:
-        from image_readers import set_lib_name
-        set_lib_name(options.lib_name)
+        fast_dp.image_readers.set_lib_name(options.lib_name)
 
     try:
         write('Fast_DP version %s' % fast_dp.__version__)

--- a/fast_dp/image_readers.py
+++ b/fast_dp/image_readers.py
@@ -28,18 +28,17 @@ def get_dectris_serial_no(record):
     tokens = record.split()
     return tokens[tokens.index('S/N') + 1]
 
-__hdf5_lib = ''
 def find_hdf5_lib(lib_name=None):
-  global __hdf5_lib
-  if __hdf5_lib:
-    return __hdf5_lib
-  if lib_name is None:
-    'dectris-neggia.so'
-  for d in os.environ['PATH'].split(os.pathsep):
-    if os.path.exists(os.path.join(d, 'xds_par')):
-      __hdf5_lib = 'LIB=%s\n' % os.path.join(d, lib_name)
-      return __hdf5_lib
-  return ''
+  if not hasattr(find_hdf5_lib, 'cache'):
+    lib_name = lib_name or 'dectris-neggia.so'
+    for d in os.environ['PATH'].split(os.pathsep):
+      if os.path.exists(os.path.join(d, 'xds_par')):
+        library = 'LIB=%s\n' % os.path.join(d, lib_name)
+        break
+    else:
+      library = ''
+    setattr(find_hdf5_lib, 'cache', library)
+  return getattr(find_hdf5_lib, 'cache')
 
 try:
   import bz2


### PR DESCRIPTION
Same as #22 but for master branch
* refactor HDF5 library search
  fixes case when ```lib_name``` is unset and avoids global variable
* fix ```-l``` command line option
