### PR TITLE
Use dxtbx to calculate refined beam centre from xparm.xds

### DIFF
--- a/fast_dp/scale.py
+++ b/fast_dp/scale.py
@@ -6,6 +6,7 @@ import shutil
 from fast_dp.run_job import run_job
 from fast_dp.cell_spacegroup import spacegroup_number_to_name
 from fast_dp.autoindex import segment_text
+from fast_dp.xds_reader import read_xparm_get_refined_beam
 
 
 def scale(unit_cell, xds_inp, space_group_number, resolution_high=0.0):
@@ -71,15 +72,7 @@ def scale(unit_cell, xds_inp, space_group_number, resolution_high=0.0):
     # and the total number of good reflections
     nref = 0
 
-    # set the refined beam in case it was not refined correctly in the
-    # global refinement (this probably indicates a bigger problem anyway)
-    refined_beam = 0, 0
-
-    for record in open("CORRECT.LP", "r").readlines():
-        if "NUMBER OF ACCEPTED OBSERVATIONS" in record:
-            nref = int(record.replace(")", ") ").split()[-1])
-        if "DETECTOR COORDINATES (PIXELS) OF DIRECT BEAM" in record:
-            refined_beam = tuple(map(float, record.split()[-2:]))
+    refined_beam = read_xparm_get_refined_beam("GXPARM.XDS")
 
     # hack in xdsstat (but don't cry if it fails)
 


### PR DESCRIPTION
This uses dxtbx to calculate the refined beam centre in raw
image coordinates, rather than taking the reported direct
beam coordinates from CORRECT.LP. For simple single panel
detectors this should be exactly equivalent, but for multi-panel
detectors the values XDS reports in CORRECT.LP are in a virtual
detector plane, and don't necessarily correspond to either the
raw image coordinates or any panel coordinates.
See also https://github.com/xia2/xia2/commit/a36beb0cf07f8e9684ced79baf776c97bf90d2d2
and SCI-8519.

Before/after on example DLS I23 dataset:
```
$ grep beam -i master/fast_dp.xml
<refinedXBeam>-0.256280</refinedXBeam>
<refinedYBeam>-1.062960</refinedYBeam>
$ grep beam -i branch/fast_dp.xml
<refinedXBeam>445.690877</refinedXBeam>
<refinedYBeam>183.634775</refinedYBeam>
```