### PR TITLE
Fix mock import

### DIFF
--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import, division, print_function
 
-import mock
 import os
 import pytest
 import sys
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 def test_fast_dp_X4_wide(capsys, tmpdir):


### PR DESCRIPTION
I appear to be missing something to run the full suite of tests, but it gets past the `import mock` part of it now.