### PR TITLE
Update github artifact actions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,20 +8,6 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  Lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-      - name: Lint with Ruff
-        run: |
-          pip install ruff
-          ruff --output-format=github --target-version=py39 .
-        continue-on-error: true
-
   Build:
     runs-on: ubuntu-latest
     steps:
@@ -52,14 +38,14 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
-        - os: windows-latest
-          python-version: "3.10"
-        - os: windows-latest
-          python-version: "3.11"
-        - os: macos-latest
-          python-version: "3.10"
-        - os: macos-latest
-          python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.11"
+          - os: macos-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.11"
     runs-on: ${{ matrix.os }}
     # runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           python -m build
           pip install dist/*.whl
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist/*
 
@@ -64,7 +64,7 @@ jobs:
     # runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
@@ -98,7 +98,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,16 @@
+ci:
+  autoupdate_schedule: quarterly
+
 repos:
-
-# Automatic source code formatting
-- repo: https://github.com/psf/black
-  rev: 23.9.1
-  hooks:
-  - id: black
-    args: [--safe, --quiet]
-
-# Syntax check and some basic
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
-  hooks:
-  - id: check-ast
-
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.291
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.9.2
   hooks:
     - id: ruff
-      args: ["--fix", "--show-fixes"]
+      args: [--fix, --exit-non-zero-on-fix, --show-fixes]
+    - id: ruff-format
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+  - id: check-ast
 


### PR DESCRIPTION
The old versions are deprecated.

Also, update pre-commit in preparation for turning on pre-commit.ci.